### PR TITLE
Update Package@swift-5.9.swift

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "FlyHUD",
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12),
+        .iOS(.v13),
+        .tvOS(.v13),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
Views> BackgroundView. This fixes Xcode 16.3 compile error "'systemThickMaterial' is only available in iOS 13.0 or newer" by increasing the Package.swift-5.9 to

let package = Package(
    name: "FlyHUD",
    platforms: [
        .iOS(.v13),
        .tvOS(.v13),
        .visionOS(.v1)
    ],
...)